### PR TITLE
fix: webhook filtering, ignored reason codes, docs, and path redirect (#2 #3 #4 #5)

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,8 @@ Point your Linear, GitHub, and PostHog webhooks at:
 | GitHub   | `http://localhost:8080/webhooks/github`   |
 | PostHog  | `http://localhost:8080/webhooks/posthog`  |
 
+> **Note:** The path is `/webhooks/` (plural). Using `/webhook/` (singular) will redirect automatically, but configure your webhook provider with the correct plural path to avoid the extra round-trip.
+
 Check health: `curl http://localhost:8080/health`
 
 ---

--- a/docs/adapters.md
+++ b/docs/adapters.md
@@ -104,6 +104,41 @@ GitHub: PR #42 'Add retry middleware' merged — kahunahana/heartbeat-gateway
 GitHub: PR #43 review approved — kahunahana/heartbeat-gateway
 ```
 
+### Manual Testing
+
+GitHub always sends `X-GitHub-Event` and `X-Hub-Signature-256` on real webhooks, but curl requests omit them by default — causing events to be silently ignored.
+
+**Step 1 — Compute the HMAC signature:**
+
+```bash
+PAYLOAD='{"action":"opened","pull_request":{"title":"Test PR","head":{"ref":"feature/test"},"base":{"ref":"main"},"number":1,"html_url":"https://github.com/owner/repo/pull/1"},"repository":{"full_name":"owner/repo"}}'
+SECRET=your-webhook-secret
+
+SIG=$(echo -n "$PAYLOAD" | openssl dgst -sha256 -hmac "$SECRET" | awk '{print "sha256="$2}')
+```
+
+**Step 2 — Send the request:**
+
+```bash
+curl -X POST http://localhost:8080/webhooks/github \
+  -H "Content-Type: application/json" \
+  -H "X-GitHub-Event: pull_request" \
+  -H "X-Hub-Signature-256: $SIG" \
+  -d "$PAYLOAD"
+```
+
+**Other common `X-GitHub-Event` values for testing:**
+
+| Event | `X-GitHub-Event` value |
+|-------|------------------------|
+| Pull request | `pull_request` |
+| CI check run | `check_run` |
+| Push | `push` |
+| Issue | `issues` |
+| PR review | `pull_request_review` |
+
+> **Tip:** If the gateway returns `{"status":"ignored","reason":"unrecognized_event_type"}`, the adapter returned `None` — check that `X-GitHub-Event` matches one of the handled events above and that the payload structure is correct.
+
 ---
 
 ## PostHog

--- a/heartbeat_gateway/app.py
+++ b/heartbeat_gateway/app.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import json
 
 from fastapi import FastAPI, Request
-from fastapi.responses import JSONResponse
+from fastapi.responses import JSONResponse, RedirectResponse
 from loguru import logger
 
 from heartbeat_gateway.adapters.github import GitHubAdapter
@@ -31,11 +31,11 @@ async def _process_webhook(request: Request, source: str):
         event = adapter.normalize(payload, headers)
 
         if event is None:
-            return {"status": "ignored"}
+            return {"status": "ignored", "reason": "unrecognized_event_type"}
 
-        should_drop, _ = state.pre_filter.should_drop(event, state.config)
+        should_drop, reason = state.pre_filter.should_drop(event, state.config)
         if should_drop:
-            return {"status": "ignored"}
+            return {"status": "ignored", "reason": reason}
 
         verdict = await state.classifier.classify(event)
 
@@ -45,7 +45,7 @@ async def _process_webhook(request: Request, source: str):
         if verdict.verdict == "DELTA":
             state.writer.write_delta(event)
             return {"status": "delta"}
-        return {"status": "ignored"}
+        return {"status": "ignored", "reason": verdict.rationale}
 
     except Exception as exc:
         logger.error("Unhandled exception in {} webhook: {}", source, exc)
@@ -76,6 +76,19 @@ def create_app(config: GatewayConfig | None = None) -> FastAPI:
     @app.post("/webhooks/posthog")
     async def posthog_webhook(request: Request):
         return await _process_webhook(request, "posthog")
+
+    # Redirect singular /webhook/{source} → /webhooks/{source} (308 preserves POST method)
+    @app.post("/webhook/linear", include_in_schema=False)
+    async def redirect_linear():
+        return RedirectResponse(url="/webhooks/linear", status_code=308)
+
+    @app.post("/webhook/github", include_in_schema=False)
+    async def redirect_github():
+        return RedirectResponse(url="/webhooks/github", status_code=308)
+
+    @app.post("/webhook/posthog", include_in_schema=False)
+    async def redirect_posthog():
+        return RedirectResponse(url="/webhooks/posthog", status_code=308)
 
     @app.get("/health")
     async def health():

--- a/heartbeat_gateway/pre_filter.py
+++ b/heartbeat_gateway/pre_filter.py
@@ -47,10 +47,11 @@ class PreFilter:
             if watched_repos and event_repo and event_repo not in watched_repos:
                 return True, f"repo_not_watched:{event_repo}"
 
-            # Branch scoping for push and CI events
+            # Branch scoping for push and CI events only — not PRs, whose branches are ephemeral
+            BRANCH_SCOPED_EVENTS = {"push", "ci.failure", "ci.success"}
             watched_branches = config.watch.github.branches
             event_branch = event.metadata.get("branch", "")
-            if event_branch and watched_branches and event_branch not in watched_branches:
+            if event.event_type in BRANCH_SCOPED_EVENTS and event_branch and watched_branches and event_branch not in watched_branches:
                 return True, f"branch_not_watched:{event_branch}"
 
         # 3. Linear project scoping

--- a/heartbeat_gateway/pre_filter.py
+++ b/heartbeat_gateway/pre_filter.py
@@ -51,9 +51,12 @@ class PreFilter:
             BRANCH_SCOPED_EVENTS = {"push", "ci.failure", "ci.success"}
             watched_branches = config.watch.github.branches
             event_branch = event.metadata.get("branch", "")
-            if (event.event_type in BRANCH_SCOPED_EVENTS
-                    and event_branch and watched_branches
-                    and event_branch not in watched_branches):
+            if (
+                event.event_type in BRANCH_SCOPED_EVENTS
+                and event_branch
+                and watched_branches
+                and event_branch not in watched_branches
+            ):
                 return True, f"branch_not_watched:{event_branch}"
 
         # 3. Linear project scoping

--- a/heartbeat_gateway/pre_filter.py
+++ b/heartbeat_gateway/pre_filter.py
@@ -51,7 +51,9 @@ class PreFilter:
             BRANCH_SCOPED_EVENTS = {"push", "ci.failure", "ci.success"}
             watched_branches = config.watch.github.branches
             event_branch = event.metadata.get("branch", "")
-            if event.event_type in BRANCH_SCOPED_EVENTS and event_branch and watched_branches and event_branch not in watched_branches:
+            if (event.event_type in BRANCH_SCOPED_EVENTS
+                    and event_branch and watched_branches
+                    and event_branch not in watched_branches):
                 return True, f"branch_not_watched:{event_branch}"
 
         # 3. Linear project scoping

--- a/main.py
+++ b/main.py
@@ -11,6 +11,7 @@ Or uvicorn directly:
 
     uv run uvicorn heartbeat_gateway.app:create_app --factory --host 0.0.0.0 --port 8080
 """
+
 from heartbeat_gateway.app import main
 
 if __name__ == "__main__":

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -60,7 +60,7 @@ def test_linear_comment_unrelated_not_written(client, config):
     with patch("litellm.acompletion", _llm_mock("IGNORE", "unrelated to watched work")):
         resp = client.post("/webhooks/linear", json=payload)
     assert resp.status_code == 200
-    assert resp.json() == {"status": "ignored"}
+    assert resp.json()["status"] == "ignored"
     assert not (config.workspace_path / "HEARTBEAT.md").exists()
 
 
@@ -96,7 +96,7 @@ def test_github_star_ignored_no_llm(client, config):
             headers={"X-GitHub-Event": "star"},
         )
     assert resp.status_code == 200
-    assert resp.json() == {"status": "ignored"}
+    assert resp.json()["status"] == "ignored"
     assert not (config.workspace_path / "HEARTBEAT.md").exists()
 
 
@@ -110,7 +110,7 @@ def test_posthog_pageview_ignored_no_llm(client, config):
     with patch("litellm.acompletion", AsyncMock(side_effect=AssertionError("LLM must not be called"))):
         resp = client.post("/webhooks/posthog", json=payload)
     assert resp.status_code == 200
-    assert resp.json() == {"status": "ignored"}
+    assert resp.json()["status"] == "ignored"
     assert not (config.workspace_path / "HEARTBEAT.md").exists()
 
 

--- a/tests/test_pre_filter.py
+++ b/tests/test_pre_filter.py
@@ -111,6 +111,14 @@ def test_github_watched_branch_passes(pre_filter: PreFilter, tmp_path: Path) -> 
     assert not dropped
 
 
+def test_github_pr_from_feature_branch_not_dropped(pre_filter: PreFilter, tmp_path: Path) -> None:
+    """PR events must not be branch-filtered — PR branches are ephemeral and never 'main'."""
+    config = make_config(tmp_path, github=GitHubWatchConfig(branches=["main"]))
+    event = make_event("github", "pull_request", metadata={"repo": "owner/repo", "branch": "feature/my-feature"})
+    dropped, reason = pre_filter.should_drop(event, config)
+    assert not dropped, f"PR event was incorrectly dropped: {reason}"
+
+
 # --- Linear scoping ---
 
 

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -203,7 +203,7 @@ def test_posthog_webhook_invalid_signature(app, client):
 # ── Pipeline edge-case tests ──────────────────────────────────────────────────
 
 
-def test_prefilter_drop_returns_ignored(app, client, linear_event):
+def test_prefilter_drop_returns_ignored_with_reason(app, client, linear_event):
     app.state.linear_adapter.verify_signature.return_value = True
     app.state.linear_adapter.normalize.return_value = linear_event
     app.state.pre_filter.should_drop.return_value = (True, "always_drop:Issue.viewed")
@@ -211,22 +211,26 @@ def test_prefilter_drop_returns_ignored(app, client, linear_event):
     resp = client.post("/webhooks/linear", json=LINEAR_PAYLOAD)
 
     assert resp.status_code == 200
-    assert resp.json() == {"status": "ignored"}
+    body = resp.json()
+    assert body["status"] == "ignored"
+    assert body["reason"] == "always_drop:Issue.viewed"
     app.state.classifier.classify.assert_not_called()
 
 
-def test_adapter_normalize_none_returns_ignored(app, client):
+def test_adapter_normalize_none_returns_ignored_with_reason(app, client):
     app.state.linear_adapter.verify_signature.return_value = True
     app.state.linear_adapter.normalize.return_value = None
 
     resp = client.post("/webhooks/linear", json={"type": "unknown_event"})
 
     assert resp.status_code == 200
-    assert resp.json() == {"status": "ignored"}
+    body = resp.json()
+    assert body["status"] == "ignored"
+    assert body["reason"] == "unrecognized_event_type"
     app.state.classifier.classify.assert_not_called()
 
 
-def test_classifier_ignore_verdict_returns_ignored(app, client, linear_event, ignore_verdict):
+def test_classifier_ignore_verdict_returns_ignored_with_reason(app, client, linear_event, ignore_verdict):
     app.state.linear_adapter.verify_signature.return_value = True
     app.state.linear_adapter.normalize.return_value = linear_event
     app.state.classifier.classify = AsyncMock(return_value=ignore_verdict)
@@ -234,7 +238,9 @@ def test_classifier_ignore_verdict_returns_ignored(app, client, linear_event, ig
     resp = client.post("/webhooks/linear", json=LINEAR_PAYLOAD)
 
     assert resp.status_code == 200
-    assert resp.json() == {"status": "ignored"}
+    body = resp.json()
+    assert body["status"] == "ignored"
+    assert body["reason"] == "not relevant"
     app.state.writer.write_actionable.assert_not_called()
     app.state.writer.write_delta.assert_not_called()
 
@@ -247,3 +253,15 @@ def test_health_endpoint(client):
 
     assert resp.status_code == 200
     assert resp.json() == {"status": "ok", "version": "0.1.0"}
+
+
+# ── Singular path redirect tests ──────────────────────────────────────────────
+
+
+@pytest.mark.parametrize("source", ["linear", "github", "posthog"])
+def test_singular_webhook_path_redirects(client, source):
+    """POST /webhook/{source} (singular) must 308-redirect to /webhooks/{source} (plural)."""
+    resp = client.post(f"/webhook/{source}", json={}, follow_redirects=False)
+
+    assert resp.status_code == 308
+    assert resp.headers["location"] == f"/webhooks/{source}"

--- a/tests/test_writer.py
+++ b/tests/test_writer.py
@@ -129,6 +129,7 @@ def test_warns_when_no_active_tasks_heading(
     heartbeat_path = config.workspace_path / "HEARTBEAT.md"
     heartbeat_path.write_text("# Heartbeat Tasks\n\nSome content without the expected heading.\n", encoding="utf-8")
     import logging
+
     with caplog.at_level(logging.WARNING):
         writer.write_actionable(sample_entry)
     assert ACTIVE_TASKS_MARKER not in heartbeat_path.read_text()


### PR DESCRIPTION
## Summary

- **#2** — Branch filter in `pre_filter.py` was silently dropping all PR events from non-main branches. Added `BRANCH_SCOPED_EVENTS` guard so branch scoping only applies to `push`, `ci.failure`, and `ci.success`.
- **#3** — All three ignored-response paths in `app.py` now return a `reason` field (`unrecognized_event_type`, pre-filter reason string, or classifier rationale) so operators can diagnose drops without reading source code.
- **#4** — Added a **Manual Testing** section to `docs/adapters.md` with the `openssl` signing command and a complete `curl` example including `X-GitHub-Event` and `X-Hub-Signature-256` headers.
- **#5** — Added a callout note in the README quickstart flagging the plural `/webhooks/` path. Added `308 Permanent Redirect` routes for `/webhook/{linear,github,posthog}` so the common mistake self-corrects without operator intervention.

## Test plan

- [x] `pytest tests/test_pre_filter.py` — 29 tests pass including new `test_github_pr_from_feature_branch_not_dropped`
- [x] `pytest tests/test_server.py` — 13 tests pass including 3 updated reason-code tests and 3 new redirect tests
- [x] All 42 tests pass with `pytest tests/test_pre_filter.py tests/test_server.py`

🤖 Generated with [Claude Code](https://claude.com/claude-code)