### PR TITLE
fix: enforce JSON output format on classifier LLM calls (#7)

### DIFF
--- a/heartbeat_gateway/classifier.py
+++ b/heartbeat_gateway/classifier.py
@@ -76,6 +76,7 @@ class Classifier:
                 model=self._config.llm_model,
                 api_key=self._config.llm_api_key,
                 messages=[{"role": "user", "content": prompt}],
+                response_format={"type": "json_object"},
             )
             raw = response.choices[0].message.content or ""
             data = json.loads(raw)

--- a/tests/test_classifier.py
+++ b/tests/test_classifier.py
@@ -126,6 +126,23 @@ async def test_missing_heartbeat_md_completes(tmp_path: Path) -> None:
     assert verdict.verdict == "IGNORE"
 
 
+async def test_response_format_json_object_is_set(tmp_path: Path) -> None:
+    """classifier must pass response_format={"type":"json_object"} to prevent markdown-fenced responses."""
+    config = make_config(tmp_path)
+    captured: list[dict] = []
+
+    async def capturing_mock(**kwargs: object) -> MagicMock:
+        captured.append(kwargs)  # type: ignore[arg-type]
+        response = MagicMock()
+        response.choices[0].message.content = json.dumps({"classification": "IGNORE", "rationale": "test"})
+        return response
+
+    with patch("litellm.acompletion", capturing_mock):
+        await Classifier(config).classify(make_event())
+
+    assert captured[0].get("response_format") == {"type": "json_object"}
+
+
 async def test_prompt_contains_payload_condensed(tmp_path: Path) -> None:
     config = make_config(tmp_path)
     event = make_event(payload_condensed="unique-payload-marker-xyz")


### PR DESCRIPTION
## Summary

- Adds `response_format={"type": "json_object"}` to the `litellm.acompletion` call in `classifier.py`
- Fixes #7 — Claude models frequently wrap JSON in markdown fences (` ```json ``` `) despite prompt instructions, causing `json.loads()` to raise `JSONDecodeError`, which was silently caught and returned as `IGNORE`, dropping every event that reached the LLM stage
- Structured output enforcement happens at the API level — no fragile string-stripping heuristics

## Test plan

- [ ] New test `test_response_format_json_object_is_set` asserts `response_format` is passed on every `classify()` call
- [ ] All 102 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)