### PR TITLE
fix: make classifier JSON parsing reliable (closes #7 properly)

### DIFF
--- a/heartbeat_gateway/classifier.py
+++ b/heartbeat_gateway/classifier.py
@@ -71,18 +71,31 @@ class Classifier:
             current_tasks=current_tasks,
         )
 
+        api_key = self._config.llm_api_key or None
         try:
-            response = await litellm.acompletion(
-                model=self._config.llm_model,
-                api_key=self._config.llm_api_key,
-                messages=[{"role": "user", "content": prompt}],
-                response_format={"type": "json_object"},
-            )
+            try:
+                response = await litellm.acompletion(
+                    model=self._config.llm_model,
+                    api_key=api_key,
+                    messages=[{"role": "user", "content": prompt}],
+                    response_format={"type": "json_object"},
+                )
+            except litellm.UnsupportedParamsError:
+                # response_format not supported for this model/version — retry without it
+                response = await litellm.acompletion(
+                    model=self._config.llm_model,
+                    api_key=api_key,
+                    messages=[{"role": "user", "content": prompt}],
+                )
             raw = response.choices[0].message.content or ""
+            raw = raw.strip()
+            if raw.startswith("```"):
+                # Strip markdown code fencing the model may add despite prompt instructions
+                raw = raw.split("\n", 1)[-1].rsplit("```", 1)[0].strip()
             data = json.loads(raw)
             verdict_str: str = data["classification"]
         except Exception as exc:
-            logger.warning("Classifier error: {}", exc)
+            logger.error("Classifier error ({}: {})", type(exc).__name__, exc)
             return ClassifierVerdict(verdict="IGNORE", rationale="classifier error")
 
         if verdict_str not in _VALID_VERDICTS:

--- a/heartbeat_gateway/config/schema.py
+++ b/heartbeat_gateway/config/schema.py
@@ -1,6 +1,6 @@
 from pathlib import Path
 
-from pydantic import Field
+from pydantic import AliasChoices, Field
 from pydantic_settings import BaseSettings
 
 
@@ -47,7 +47,10 @@ class GatewayConfig(BaseSettings):
     workspace_path: Path = Field(default_factory=lambda: Path("~/workspace").expanduser())
     soul_md_path: Path = Field(default_factory=lambda: Path("~/workspace/SOUL.md").expanduser())
     llm_model: str = "claude-haiku-4-5-20251001"
-    llm_api_key: str = Field(default="", alias="ANTHROPIC_API_KEY")
+    llm_api_key: str = Field(
+        default="",
+        validation_alias=AliasChoices("ANTHROPIC_API_KEY", "GATEWAY_LLM_API_KEY"),
+    )
     heartbeat_max_active_tasks: int = 20
     audit_log_path: Path | None = None
     watch: WatchConfig = Field(default_factory=WatchConfig)

--- a/tests/test_classifier.py
+++ b/tests/test_classifier.py
@@ -149,9 +149,7 @@ async def test_markdown_fenced_json_is_parsed(tmp_path: Path) -> None:
     """Classifier must parse JSON even when the model wraps it in markdown fencing."""
     config = make_config(tmp_path)
     response = MagicMock()
-    response.choices[0].message.content = (
-        '```json\n{"classification": "IGNORE", "rationale": "fenced response"}\n```'
-    )
+    response.choices[0].message.content = '```json\n{"classification": "IGNORE", "rationale": "fenced response"}\n```'
 
     with patch("litellm.acompletion", AsyncMock(return_value=response)):
         verdict = await Classifier(config).classify(make_event())

--- a/tests/test_classifier.py
+++ b/tests/test_classifier.py
@@ -5,6 +5,8 @@ from datetime import datetime, timezone
 from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, patch
 
+import litellm
+
 from heartbeat_gateway import NormalizedEvent
 from heartbeat_gateway.classifier import Classifier
 from heartbeat_gateway.config.schema import GatewayConfig
@@ -141,6 +143,46 @@ async def test_response_format_json_object_is_set(tmp_path: Path) -> None:
         await Classifier(config).classify(make_event())
 
     assert captured[0].get("response_format") == {"type": "json_object"}
+
+
+async def test_markdown_fenced_json_is_parsed(tmp_path: Path) -> None:
+    """Classifier must parse JSON even when the model wraps it in markdown fencing."""
+    config = make_config(tmp_path)
+    response = MagicMock()
+    response.choices[0].message.content = (
+        '```json\n{"classification": "IGNORE", "rationale": "fenced response"}\n```'
+    )
+
+    with patch("litellm.acompletion", AsyncMock(return_value=response)):
+        verdict = await Classifier(config).classify(make_event())
+
+    assert verdict.verdict == "IGNORE"
+    assert verdict.rationale == "fenced response"
+
+
+async def test_unsupported_params_retries_without_response_format(tmp_path: Path) -> None:
+    """If response_format raises UnsupportedParamsError, classifier retries without it."""
+    config = make_config(tmp_path)
+    success_response = MagicMock()
+    success_response.choices[0].message.content = json.dumps({"classification": "IGNORE", "rationale": "retry ok"})
+
+    call_count = 0
+
+    async def side_effect_mock(**kwargs: object) -> MagicMock:
+        nonlocal call_count
+        call_count += 1
+        if call_count == 1:
+            raise litellm.UnsupportedParamsError(
+                model="test", llm_provider="anthropic", message="response_format not supported"
+            )
+        return success_response
+
+    with patch("litellm.acompletion", side_effect_mock):
+        verdict = await Classifier(config).classify(make_event())
+
+    assert call_count == 2
+    assert verdict.verdict == "IGNORE"
+    assert verdict.rationale == "retry ok"
 
 
 async def test_prompt_contains_payload_condensed(tmp_path: Path) -> None:


### PR DESCRIPTION
## Problem

Issue #7's fix added `response_format={"type": "json_object"}` to the LiteLLM call, but the bug persisted because the fix introduced a new failure mode it couldn't detect: `litellm.UnsupportedParamsError`. The broad `except Exception` caught it silently, producing the same `{"status":"ignored","reason":"classifier error"}` response.

Three root causes were found:

1. `response_format={"type": "json_object"}` raises `litellm.UnsupportedParamsError` on LiteLLM versions that don't map this parameter for Anthropic models
2. `llm_api_key` used `alias="ANTHROPIC_API_KEY"` which pydantic-settings v2 prefixes to `GATEWAY_ANTHROPIC_API_KEY` — the standard `ANTHROPIC_API_KEY` env var was never picked up
3. `api_key=""` (empty string) behaves differently from `api_key=None` in some LiteLLM versions — `None` correctly triggers LiteLLM's own env-var fallback

## Changes

**`classifier.py`**
- Catch `litellm.UnsupportedParamsError` specifically and retry without `response_format` — classifier works across all LiteLLM versions `>=1.50.0`
- Strip markdown code fencing before `json.loads()` — defense-in-depth for when `response_format` is silently ignored
- Pass `api_key=None` (not `""`) when config value is empty
- Upgrade classifier error log from `warning` to `error`, include exception type

**`config/schema.py`**
- Replace `alias="ANTHROPIC_API_KEY"` with `validation_alias=AliasChoices("ANTHROPIC_API_KEY", "GATEWAY_LLM_API_KEY")` so the standard env var is found without the `GATEWAY_` prefix

**`tests/test_classifier.py`**
- Add `test_markdown_fenced_json_is_parsed` — exercises the stripping path directly
- Add `test_unsupported_params_retries_without_response_format` — verifies the retry logic fires on `UnsupportedParamsError`

## Test results

104 passed (was 102)

🤖 Generated with [Claude Code](https://claude.com/claude-code)