### PR TITLE
fix: v0.2.0 production hardening — file locking, signature enforcement, failed-event recovery, security

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,6 +12,17 @@ RUN uv sync --frozen --no-dev
 # Copy source
 COPY heartbeat_gateway/ ./heartbeat_gateway/
 
+# Create non-root user and workspace directory
+RUN useradd -m -u 1000 agent && \
+    mkdir -p /workspace && \
+    chown -R agent:agent /workspace /app
+
+# Declare workspace as named volume
+VOLUME ["/workspace"]
+
+# Switch to non-root user
+USER agent
+
 EXPOSE 8080
 
 CMD ["uv", "run", "uvicorn", "heartbeat_gateway.app:create_app", \

--- a/heartbeat_gateway/app.py
+++ b/heartbeat_gateway/app.py
@@ -21,14 +21,17 @@ MAX_BODY_BYTES = 10 * 1024  # 10 KB
 
 async def _process_webhook(request: Request, source: str):
     body = await request.body()
+
     if len(body) > MAX_BODY_BYTES:
         return JSONResponse(
             {"status": "error", "reason": "payload_too_large"},
             status_code=413,
         )
+
     headers = dict(request.headers)
     state = request.app.state
     adapter = getattr(state, f"{source}_adapter")
+    event = None  # tracked for failed-event logging
 
     try:
         if not adapter.verify_signature(body, headers):
@@ -59,6 +62,11 @@ async def _process_webhook(request: Request, source: str):
 
     except Exception as exc:
         logger.error("Unhandled exception in {} webhook: {}", source, exc)
+        if event is not None:
+            try:
+                state.writer.write_failed(event, reason=f"{type(exc).__name__}: {exc}")
+            except Exception:
+                pass  # never let audit logging crash the error handler
         return JSONResponse({"status": "error"}, status_code=500)
 
 

--- a/heartbeat_gateway/app.py
+++ b/heartbeat_gateway/app.py
@@ -16,9 +16,16 @@ from heartbeat_gateway.writer import HeartbeatWriter
 
 VERSION = "0.1.1"
 
+MAX_BODY_BYTES = 10 * 1024  # 10 KB
+
 
 async def _process_webhook(request: Request, source: str):
     body = await request.body()
+    if len(body) > MAX_BODY_BYTES:
+        return JSONResponse(
+            {"status": "error", "reason": "payload_too_large"},
+            status_code=413,
+        )
     headers = dict(request.headers)
     state = request.app.state
     adapter = getattr(state, f"{source}_adapter")

--- a/heartbeat_gateway/app.py
+++ b/heartbeat_gateway/app.py
@@ -14,7 +14,7 @@ from heartbeat_gateway.config.schema import GatewayConfig
 from heartbeat_gateway.pre_filter import PreFilter
 from heartbeat_gateway.writer import HeartbeatWriter
 
-VERSION = "0.1.1"
+VERSION = "0.2.0"
 
 MAX_BODY_BYTES = 10 * 1024  # 10 KB
 

--- a/heartbeat_gateway/app.py
+++ b/heartbeat_gateway/app.py
@@ -59,6 +59,21 @@ def create_app(config: GatewayConfig | None = None) -> FastAPI:
     if config is None:
         config = GatewayConfig()
 
+    if config.require_signatures:
+        missing = []
+        if not config.watch.linear.secret:
+            missing.append("linear")
+        if not config.watch.github.secret:
+            missing.append("github")
+        if not config.watch.posthog.secret:
+            missing.append("posthog")
+        if missing:
+            raise ValueError(
+                f"GATEWAY_REQUIRE_SIGNATURES=true but no secret configured for: "
+                f"{', '.join(missing)}. "
+                f"Set GATEWAY_WATCH__{{SOURCE}}__SECRET for each source."
+            )
+
     app = FastAPI()
     app.state.config = config
     app.state.pre_filter = PreFilter()

--- a/heartbeat_gateway/classifier.py
+++ b/heartbeat_gateway/classifier.py
@@ -35,14 +35,14 @@ def _render(template: str, **kwargs: str) -> str:
     return result
 
 
-def _read_soul_excerpt(path: Path) -> str:
+def _read_soul_excerpt(path: Path, max_chars: int = 500) -> str:
     try:
-        return path.read_text(encoding="utf-8")[:500]
+        return path.read_text(encoding="utf-8")[:max_chars]
     except OSError:
         return ""
 
 
-def _read_current_tasks(heartbeat_path: Path) -> str:
+def _read_current_tasks(heartbeat_path: Path, max_chars: int = 1200) -> str:
     try:
         content = heartbeat_path.read_text(encoding="utf-8")
     except OSError:
@@ -51,7 +51,7 @@ def _read_current_tasks(heartbeat_path: Path) -> str:
     if idx == -1:
         return ""
     lines = content[idx:].splitlines()
-    return "\n".join(lines[-10:])
+    return "\n".join(lines[-10:])[:max_chars]
 
 
 class Classifier:
@@ -60,8 +60,14 @@ class Classifier:
         self._template = _load_prompt_template()
 
     async def classify(self, event: NormalizedEvent) -> ClassifierVerdict:
-        soul_excerpt = _read_soul_excerpt(self._config.soul_md_path)
-        current_tasks = _read_current_tasks(self._config.workspace_path / "HEARTBEAT.md")
+        soul_excerpt = _read_soul_excerpt(
+            self._config.soul_md_path,
+            max_chars=self._config.soul_excerpt_chars,
+        )
+        current_tasks = _read_current_tasks(
+            self._config.workspace_path / "HEARTBEAT.md",
+            max_chars=self._config.active_tasks_chars,
+        )
 
         prompt = _render(
             self._template,

--- a/heartbeat_gateway/config/schema.py
+++ b/heartbeat_gateway/config/schema.py
@@ -52,5 +52,7 @@ class GatewayConfig(BaseSettings):
         validation_alias=AliasChoices("ANTHROPIC_API_KEY", "GATEWAY_LLM_API_KEY"),
     )
     heartbeat_max_active_tasks: int = 20
+    soul_excerpt_chars: int = Field(default=500, ge=100, le=10000)
+    active_tasks_chars: int = Field(default=1200, ge=100, le=10000)
     audit_log_path: Path | None = None
     watch: WatchConfig = Field(default_factory=WatchConfig)

--- a/heartbeat_gateway/config/schema.py
+++ b/heartbeat_gateway/config/schema.py
@@ -55,4 +55,5 @@ class GatewayConfig(BaseSettings):
     soul_excerpt_chars: int = Field(default=500, ge=100, le=10000)
     active_tasks_chars: int = Field(default=1200, ge=100, le=10000)
     audit_log_path: Path | None = None
+    require_signatures: bool = Field(default=False)
     watch: WatchConfig = Field(default_factory=WatchConfig)

--- a/heartbeat_gateway/mcp_server.py
+++ b/heartbeat_gateway/mcp_server.py
@@ -18,7 +18,7 @@ def read_heartbeat(workspace: Path) -> str:
     marker_pos = content.find(ACTIVE_TASKS_MARKER)
     if marker_pos == -1:
         return "No active tasks marker found in HEARTBEAT.md."
-    active = content[marker_pos + len(ACTIVE_TASKS_MARKER):]
+    active = content[marker_pos + len(ACTIVE_TASKS_MARKER) :]
     completed_pos = active.find("## Completed")
     if completed_pos != -1:
         active = active[:completed_pos]

--- a/heartbeat_gateway/writer.py
+++ b/heartbeat_gateway/writer.py
@@ -31,15 +31,19 @@ class HeartbeatWriter:
         self._heartbeat_path = config.workspace_path / "HEARTBEAT.md"
         self._delta_path = config.workspace_path / "DELTA.md"
         self._audit_path = config.audit_log_path or config.workspace_path / "audit.log"
-        self._lock = FileLock(str(self._heartbeat_path.resolve()) + ".lock")
+        self._lock = FileLock(str(self._heartbeat_path.resolve()) + ".lock", timeout=5)
 
     def heartbeat_file_exists(self) -> bool:
         return self._heartbeat_path.exists()
 
     def write_actionable(self, entry: HeartbeatEntry) -> None:
-        self._ensure_heartbeat_exists()
         with self._lock:
+            self._ensure_heartbeat_exists()
             content = self._heartbeat_path.read_text(encoding="utf-8")
+
+            if self._is_duplicate(entry, content):
+                logger.debug(f"Skipping duplicate entry: {entry.source} {entry.event_type}")
+                return
 
             max_tasks = self._config.heartbeat_max_active_tasks
             if max_tasks > 0 and self._count_active_tasks(content) >= max_tasks:
@@ -47,10 +51,6 @@ class HeartbeatWriter:
                     f"Active task cap ({max_tasks}) reached — dropping "
                     f"{entry.source}/{entry.event_type}: {entry.title}"
                 )
-                return
-
-            if self._is_duplicate(entry, content):
-                logger.debug(f"Skipping duplicate entry: {entry.source} {entry.event_type}")
                 return
 
             marker_pos = content.find(ACTIVE_TASKS_MARKER)

--- a/heartbeat_gateway/writer.py
+++ b/heartbeat_gateway/writer.py
@@ -48,8 +48,7 @@ class HeartbeatWriter:
             max_tasks = self._config.heartbeat_max_active_tasks
             if max_tasks > 0 and self._count_active_tasks(content) >= max_tasks:
                 logger.warning(
-                    f"Active task cap ({max_tasks}) reached — dropping "
-                    f"{entry.source}/{entry.event_type}: {entry.title}"
+                    f"Active task cap ({max_tasks}) reached — dropping {entry.source}/{entry.event_type}: {entry.title}"
                 )
                 return
 
@@ -95,9 +94,7 @@ class HeartbeatWriter:
         }
         with self._audit_path.open("a", encoding="utf-8") as f:
             f.write(json.dumps(record) + "\n")
-        logger.warning(
-            f"Recorded failed event for replay: {event.source}/{event.event_type} — {reason}"
-        )
+        logger.warning(f"Recorded failed event for replay: {event.source}/{event.event_type} — {reason}")
 
     def read_active_tasks(self) -> str:
         if not self._heartbeat_path.exists():
@@ -111,7 +108,7 @@ class HeartbeatWriter:
         if completed_pos != -1:
             active_section = active_section[:completed_pos]
         # Return up to the configured limit
-        return active_section.strip()[:self._config.active_tasks_chars]
+        return active_section.strip()[: self._config.active_tasks_chars]
 
     def _ensure_heartbeat_exists(self) -> None:
         self._heartbeat_path.parent.mkdir(parents=True, exist_ok=True)

--- a/heartbeat_gateway/writer.py
+++ b/heartbeat_gateway/writer.py
@@ -1,6 +1,7 @@
 import json
 from datetime import datetime, timezone
 
+from filelock import FileLock
 from loguru import logger
 
 from heartbeat_gateway import HeartbeatEntry, NormalizedEvent
@@ -30,28 +31,30 @@ class HeartbeatWriter:
         self._heartbeat_path = config.workspace_path / "HEARTBEAT.md"
         self._delta_path = config.workspace_path / "DELTA.md"
         self._audit_path = config.audit_log_path or config.workspace_path / "audit.log"
+        self._lock = FileLock(str(self._heartbeat_path) + ".lock")
 
     def heartbeat_file_exists(self) -> bool:
         return self._heartbeat_path.exists()
 
     def write_actionable(self, entry: HeartbeatEntry) -> None:
         self._ensure_heartbeat_exists()
-        content = self._heartbeat_path.read_text(encoding="utf-8")
+        with self._lock:
+            content = self._heartbeat_path.read_text(encoding="utf-8")
 
-        if self._is_duplicate(entry, content):
-            logger.debug(f"Skipping duplicate entry: {entry.source} {entry.event_type}")
-            return
+            if self._is_duplicate(entry, content):
+                logger.debug(f"Skipping duplicate entry: {entry.source} {entry.event_type}")
+                return
 
-        marker_pos = content.find(ACTIVE_TASKS_MARKER)
-        if marker_pos == -1:
-            logger.warning("HEARTBEAT.md missing write marker — appending at end")
-            content += f"\n{entry.to_markdown()}\n"
-        else:
-            insert_pos = marker_pos + len(ACTIVE_TASKS_MARKER)
-            content = content[:insert_pos] + f"\n{entry.to_markdown()}" + content[insert_pos:]
+            marker_pos = content.find(ACTIVE_TASKS_MARKER)
+            if marker_pos == -1:
+                logger.warning("HEARTBEAT.md missing write marker — appending at end")
+                content += f"\n{entry.to_markdown()}\n"
+            else:
+                insert_pos = marker_pos + len(ACTIVE_TASKS_MARKER)
+                content = content[:insert_pos] + f"\n{entry.to_markdown()}" + content[insert_pos:]
 
-        self._heartbeat_path.write_text(content, encoding="utf-8")
-        logger.info(f"Wrote actionable task: {entry.title}")
+            self._heartbeat_path.write_text(content, encoding="utf-8")
+            logger.info(f"Wrote actionable task: {entry.title}")
 
     def write_delta(self, event: NormalizedEvent) -> None:
         timestamp = event.timestamp.isoformat()

--- a/heartbeat_gateway/writer.py
+++ b/heartbeat_gateway/writer.py
@@ -41,6 +41,14 @@ class HeartbeatWriter:
         with self._lock:
             content = self._heartbeat_path.read_text(encoding="utf-8")
 
+            max_tasks = self._config.heartbeat_max_active_tasks
+            if max_tasks > 0 and self._count_active_tasks(content) >= max_tasks:
+                logger.warning(
+                    f"Active task cap ({max_tasks}) reached — dropping "
+                    f"{entry.source}/{entry.event_type}: {entry.title}"
+                )
+                return
+
             if self._is_duplicate(entry, content):
                 logger.debug(f"Skipping duplicate entry: {entry.source} {entry.event_type}")
                 return
@@ -111,6 +119,18 @@ class HeartbeatWriter:
         content = content[:insert_pos] + f"\n\n{ACTIVE_TASKS_MARKER}" + content[insert_pos:]
         self._heartbeat_path.write_text(content, encoding="utf-8")
         logger.info("Injected write marker into existing HEARTBEAT.md")
+
+    def _count_active_tasks(self, content: str) -> int:
+        """Count task entries in the active section (between write marker and ## Completed)."""
+        marker_pos = content.find(ACTIVE_TASKS_MARKER)
+        if marker_pos == -1:
+            return 0
+        active_section = content[marker_pos + len(ACTIVE_TASKS_MARKER) :]
+        completed_pos = active_section.find("## Completed")
+        if completed_pos != -1:
+            active_section = active_section[:completed_pos]
+        # Each entry starts with "- [ ] " (HeartbeatEntry.to_markdown() uses checkbox format)
+        return active_section.count("- [ ] ")
 
     def _is_duplicate(self, entry: HeartbeatEntry, content: str) -> bool:
         """Check if an identical entry is already in the active tasks section."""

--- a/heartbeat_gateway/writer.py
+++ b/heartbeat_gateway/writer.py
@@ -93,8 +93,8 @@ class HeartbeatWriter:
         completed_pos = active_section.find("## Completed")
         if completed_pos != -1:
             active_section = active_section[:completed_pos]
-        # Return up to ~300 tokens worth (~1200 chars)
-        return active_section.strip()[:1200]
+        # Return up to the configured limit
+        return active_section.strip()[:self._config.active_tasks_chars]
 
     def _ensure_heartbeat_exists(self) -> None:
         self._heartbeat_path.parent.mkdir(parents=True, exist_ok=True)

--- a/heartbeat_gateway/writer.py
+++ b/heartbeat_gateway/writer.py
@@ -31,7 +31,7 @@ class HeartbeatWriter:
         self._heartbeat_path = config.workspace_path / "HEARTBEAT.md"
         self._delta_path = config.workspace_path / "DELTA.md"
         self._audit_path = config.audit_log_path or config.workspace_path / "audit.log"
-        self._lock = FileLock(str(self._heartbeat_path) + ".lock")
+        self._lock = FileLock(str(self._heartbeat_path.resolve()) + ".lock")
 
     def heartbeat_file_exists(self) -> bool:
         return self._heartbeat_path.exists()

--- a/heartbeat_gateway/writer.py
+++ b/heartbeat_gateway/writer.py
@@ -82,6 +82,23 @@ class HeartbeatWriter:
         with self._audit_path.open("a", encoding="utf-8") as f:
             f.write(json.dumps(record) + "\n")
 
+    def write_failed(self, event: NormalizedEvent, reason: str) -> None:
+        """Record an event that failed processing so it can be identified for replay."""
+        record = {
+            "timestamp": datetime.now(tz=timezone.utc).isoformat(),
+            "source": event.source,
+            "event_type": event.event_type,
+            "classification": "FAILED",
+            "rationale": reason,
+            "condensed": event.payload_condensed,
+            "status": "failed",
+        }
+        with self._audit_path.open("a", encoding="utf-8") as f:
+            f.write(json.dumps(record) + "\n")
+        logger.warning(
+            f"Recorded failed event for replay: {event.source}/{event.event_type} — {reason}"
+        )
+
     def read_active_tasks(self) -> str:
         if not self._heartbeat_path.exists():
             return ""

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,7 @@ classifiers = [
 dependencies = [
     "fastapi>=0.115.0",
     "uvicorn[standard]>=0.32.0",
+    "filelock>=3.13",
     "litellm>=1.50.0",
     "pydantic>=2.9.0",
     "pydantic-settings>=2.6.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "heartbeat-gateway"
-version = "0.1.0"
+version = "0.2.0"
 description = "Event-driven HEARTBEAT.md writer for OpenClaw and VikingBot agents"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/railway.toml
+++ b/railway.toml
@@ -1,0 +1,13 @@
+[build]
+builder = "dockerfile"
+dockerfilePath = "Dockerfile"
+
+[deploy]
+startCommand = "uv run uvicorn heartbeat_gateway.app:create_app --factory --host 0.0.0.0 --port $PORT"
+healthcheckPath = "/health"
+healthcheckTimeout = 30
+restartPolicyType = "ON_FAILURE"
+restartPolicyMaxRetries = 3
+
+[[volumes]]
+mountPath = "/workspace"

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -74,3 +74,38 @@ def test_body_at_limit_is_not_rejected_by_size(tmp_path: Path):
         headers={"Content-Type": "application/json"},
     )
     assert response.status_code != 413
+
+
+import json as _json
+from unittest.mock import AsyncMock
+
+
+def test_classifier_failure_writes_failed_audit_record(tmp_path):
+    """When classifier raises, a failed record must appear in audit.log."""
+    config = GatewayConfig(workspace_path=tmp_path)
+    app = create_app(config)
+
+    app.state.classifier.classify = AsyncMock(side_effect=RuntimeError("LLM down"))
+    app.state.github_adapter.verify_signature = lambda body, headers: True
+
+    client = TestClient(app, raise_server_exceptions=False)
+    payload = _json.dumps({
+        "action": "opened",
+        "pull_request": {
+            "title": "test PR",
+            "html_url": "https://github.com/x/y/pull/1",
+            "number": 1,
+        }
+    })
+    response = client.post(
+        "/webhooks/github",
+        content=payload,
+        headers={"X-GitHub-Event": "pull_request", "Content-Type": "application/json"},
+    )
+
+    assert response.status_code == 500
+    audit_path = tmp_path / "audit.log"
+    assert audit_path.exists(), "audit.log must exist after failed processing"
+    records = [_json.loads(line) for line in audit_path.read_text().splitlines() if line.strip()]
+    failed = [r for r in records if r.get("status") == "failed"]
+    assert len(failed) >= 1, f"Expected failed record, got: {records}"

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -87,14 +87,16 @@ def test_classifier_failure_writes_failed_audit_record(tmp_path):
     app.state.github_adapter.verify_signature = lambda body, headers: True
 
     client = TestClient(app, raise_server_exceptions=False)
-    payload = _json.dumps({
-        "action": "opened",
-        "pull_request": {
-            "title": "test PR",
-            "html_url": "https://github.com/x/y/pull/1",
-            "number": 1,
+    payload = _json.dumps(
+        {
+            "action": "opened",
+            "pull_request": {
+                "title": "test PR",
+                "html_url": "https://github.com/x/y/pull/1",
+                "number": 1,
+            },
         }
-    })
+    )
     response = client.post(
         "/webhooks/github",
         content=payload,

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
+import json as _json
 from pathlib import Path
+from unittest.mock import AsyncMock
 
 import pytest
 from fastapi.testclient import TestClient
@@ -74,10 +76,6 @@ def test_body_at_limit_is_not_rejected_by_size(tmp_path: Path):
         headers={"Content-Type": "application/json"},
     )
     assert response.status_code != 413
-
-
-import json as _json
-from unittest.mock import AsyncMock
 
 
 def test_classifier_failure_writes_failed_audit_record(tmp_path):

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from pathlib import Path
 
 import pytest
+from fastapi.testclient import TestClient
 
 from heartbeat_gateway.app import create_app
 from heartbeat_gateway.config.schema import (
@@ -45,3 +46,31 @@ def test_require_signatures_false_allows_missing_secret(tmp_path: Path):
     config = GatewayConfig(workspace_path=tmp_path)
     app = create_app(config)
     assert app is not None
+
+
+def test_body_too_large_returns_413(tmp_path: Path):
+    """POST body >10 KB must be rejected with 413."""
+    config = GatewayConfig(workspace_path=tmp_path)
+    app = create_app(config)
+    client = TestClient(app)
+    large_body = b"x" * (10 * 1024 + 1)
+    response = client.post(
+        "/webhooks/github",
+        content=large_body,
+        headers={"Content-Type": "application/json"},
+    )
+    assert response.status_code == 413
+
+
+def test_body_at_limit_is_not_rejected_by_size(tmp_path: Path):
+    """POST body exactly at 10 KB must not be rejected by size check (reaches sig check instead)."""
+    config = GatewayConfig(workspace_path=tmp_path)
+    app = create_app(config)
+    client = TestClient(app)
+    body = b'{"event": "' + b"x" * (10 * 1024 - 20) + b'"}'
+    response = client.post(
+        "/webhooks/github",
+        content=body,
+        headers={"Content-Type": "application/json"},
+    )
+    assert response.status_code != 413

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from heartbeat_gateway.app import create_app
+from heartbeat_gateway.config.schema import (
+    GatewayConfig,
+    GitHubWatchConfig,
+    LinearWatchConfig,
+    PostHogWatchConfig,
+    WatchConfig,
+)
+
+
+def test_require_signatures_raises_on_missing_secret(tmp_path: Path):
+    """create_app must raise ValueError when require_signatures=True and a secret is absent."""
+    config = GatewayConfig(
+        workspace_path=tmp_path,
+        require_signatures=True,
+        watch=WatchConfig(github=GitHubWatchConfig(secret="")),
+    )
+    with pytest.raises(ValueError, match="github"):
+        create_app(config)
+
+
+def test_require_signatures_passes_when_all_secrets_set(tmp_path: Path):
+    """create_app must succeed when require_signatures=True and all secrets present."""
+    config = GatewayConfig(
+        workspace_path=tmp_path,
+        require_signatures=True,
+        watch=WatchConfig(
+            github=GitHubWatchConfig(secret="gh-secret"),
+            linear=LinearWatchConfig(secret="linear-secret"),
+            posthog=PostHogWatchConfig(secret="ph-secret"),
+        ),
+    )
+    app = create_app(config)
+    assert app is not None
+
+
+def test_require_signatures_false_allows_missing_secret(tmp_path: Path):
+    """Default require_signatures=False must not raise even with empty secrets."""
+    config = GatewayConfig(workspace_path=tmp_path)
+    app = create_app(config)
+    assert app is not None

--- a/tests/test_classifier.py
+++ b/tests/test_classifier.py
@@ -200,3 +200,28 @@ async def test_prompt_contains_payload_condensed(tmp_path: Path) -> None:
     assert captured, "acompletion was not called"
     messages = captured[0]["messages"]
     assert any("unique-payload-marker-xyz" in m["content"] for m in messages)
+
+
+def test_soul_excerpt_respects_max_chars(tmp_path: Path) -> None:
+    from heartbeat_gateway.classifier import _read_soul_excerpt
+
+    soul = tmp_path / "SOUL.md"
+    soul.write_text("x" * 2000)
+    result = _read_soul_excerpt(soul, max_chars=300)
+    assert len(result) == 300
+
+
+def test_soul_excerpt_missing_file_returns_empty(tmp_path: Path) -> None:
+    from heartbeat_gateway.classifier import _read_soul_excerpt
+
+    result = _read_soul_excerpt(tmp_path / "nonexistent.md", max_chars=500)
+    assert result == ""
+
+
+def test_read_current_tasks_respects_max_chars(tmp_path: Path) -> None:
+    from heartbeat_gateway.classifier import _read_current_tasks
+
+    hb = tmp_path / "HEARTBEAT.md"
+    hb.write_text("## Active Tasks\n" + "z" * 3000 + "\n## Completed\n")
+    result = _read_current_tasks(hb, max_chars=200)
+    assert len(result) <= 200

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -163,6 +163,7 @@ def test_invalid_json_returns_500(client, config):
 # ── 9. PostHog insight threshold alert → ACTIONABLE ─────────────────────────
 # PostHog adapter dispatches on payload["type"] — no event header needed.
 
+
 def test_posthog_threshold_alert_writes_heartbeat(client, config):
     msg = "Error rate exceeded threshold — investigate immediately"
     with patch("litellm.acompletion", _llm_mock("ACTIONABLE", msg)):
@@ -182,6 +183,7 @@ def test_posthog_threshold_alert_writes_heartbeat(client, config):
 # ── 10. CI failure duplicate events → deduped ────────────────────────────────
 # github_ci_failure.json produces entry.url=None (check_run adapter ignores html_url).
 # Dedup must fall back to title fingerprint: "[GITHUB:CI.FAILURE] {title}".
+
 
 def test_duplicate_ci_failure_not_written_twice(client, config):
     """CI failure has no URL — title-fingerprint dedup must prevent duplicate writes."""
@@ -203,8 +205,10 @@ def test_duplicate_ci_failure_not_written_twice(client, config):
 
 # ── 11. Audit log written for ACTIONABLE event ───────────────────────────────
 
+
 def test_audit_log_written_for_actionable(client, config):
     import json as _json
+
     rationale = "Blocked issue requires agent attention"
     with patch("litellm.acompletion", _llm_mock("ACTIONABLE", rationale)):
         payload = json.dumps(_load("linear_issue_blocked.json")).encode()

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -252,7 +252,7 @@ def test_health_endpoint(client):
     resp = client.get("/health")
 
     assert resp.status_code == 200
-    assert resp.json() == {"status": "ok", "version": "0.1.1"}
+    assert resp.json() == {"status": "ok", "version": "0.2.0"}
 
 
 # ── Singular path redirect tests ──────────────────────────────────────────────

--- a/tests/test_writer.py
+++ b/tests/test_writer.py
@@ -308,3 +308,32 @@ def test_read_active_tasks_respects_config_limit(tmp_path: Path) -> None:
     (tmp_path / "HEARTBEAT.md").write_text(content)
     result = writer.read_active_tasks()
     assert len(result) <= 100
+
+
+import json as _json
+
+
+def test_write_failed_records_to_audit_log(tmp_path):
+    """write_failed must write a JSONL record with status=failed to the audit log."""
+    from heartbeat_gateway import NormalizedEvent
+    from datetime import datetime, timezone
+
+    config = GatewayConfig(workspace_path=tmp_path)
+    writer = HeartbeatWriter(config)
+
+    event = NormalizedEvent(
+        source="github",
+        event_type="ci_failure",
+        payload_condensed="CI failed on main",
+        raw_payload={},
+        timestamp=datetime.now(tz=timezone.utc),
+    )
+    writer.write_failed(event, reason="LLM timeout")
+
+    audit_path = tmp_path / "audit.log"
+    assert audit_path.exists()
+    record = _json.loads(audit_path.read_text().strip())
+    assert record["status"] == "failed"
+    assert record["classification"] == "FAILED"
+    assert record["rationale"] == "LLM timeout"
+    assert record["source"] == "github"

--- a/tests/test_writer.py
+++ b/tests/test_writer.py
@@ -139,3 +139,123 @@ def test_config_loads_from_env(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) 
     monkeypatch.setenv("ANTHROPIC_API_KEY", "test-api-key-from-env")
     config = GatewayConfig(workspace_path=tmp_path, soul_md_path=tmp_path / "SOUL.md")
     assert config.llm_api_key == "test-api-key-from-env"
+
+
+# ---------------------------------------------------------------------------
+# Concurrency tests
+# ---------------------------------------------------------------------------
+
+
+def _make_entry(title: str, workspace: Path) -> HeartbeatEntry:
+    return HeartbeatEntry(
+        source="github",
+        event_type="ci_failure",
+        title=title,
+        timestamp=datetime.now(tz=timezone.utc),
+        url=f"https://github.com/org/repo/actions/runs/{title}",
+        priority="high",
+    )
+
+
+def test_concurrent_writes_preserve_all_entries(tmp_path: Path) -> None:
+    """Both entries must survive sequential write_actionable calls."""
+    config = GatewayConfig(workspace_path=tmp_path)
+    writer = HeartbeatWriter(config)
+    entry_a = _make_entry("run-111", tmp_path)
+    entry_b = _make_entry("run-222", tmp_path)
+    writer.write_actionable(entry_a)
+    writer.write_actionable(entry_b)
+    content = (tmp_path / "HEARTBEAT.md").read_text()
+    assert "run-111" in content
+    assert "run-222" in content
+
+
+@pytest.mark.xfail(
+    strict=True,
+    reason=(
+        "Demonstrates the pre-lock race condition. SlowWriter intentionally bypasses "
+        "FileLock to show that without a lock, last-write-wins silently drops an entry. "
+        "This test is expected to fail and must continue to do so."
+    ),
+)
+def test_race_condition_without_lock_drops_entry(tmp_path: Path) -> None:
+    """Forces concurrent interleaving via barrier — without FileLock, one entry is lost.
+
+    Uses a SlowWriter subclass that holds a barrier between read and write so
+    both threads read the same baseline content before either thread writes,
+    guaranteeing last-write-wins drops one entry when no lock is present.
+    Marked xfail(strict=True): it must always fail — if it ever passes the suite
+    breaks, which would mean the race was somehow eliminated in SlowWriter itself.
+    """
+    import threading
+
+    barrier = threading.Barrier(2)
+
+    class SlowWriter(HeartbeatWriter):
+        """Pauses between read and write to force the race window."""
+
+        def write_actionable(self, entry: HeartbeatEntry) -> None:  # type: ignore[override]
+            self._ensure_heartbeat_exists()
+            content = self._heartbeat_path.read_text(encoding="utf-8")
+            # Both threads reach the barrier before either writes — classic race.
+            barrier.wait(timeout=5)
+            if self._is_duplicate(entry, content):
+                return
+            marker_pos = content.find(ACTIVE_TASKS_MARKER)
+            if marker_pos == -1:
+                content += f"\n{entry.to_markdown()}\n"
+            else:
+                insert_pos = marker_pos + len(ACTIVE_TASKS_MARKER)
+                content = content[:insert_pos] + f"\n{entry.to_markdown()}" + content[insert_pos:]
+            self._heartbeat_path.write_text(content, encoding="utf-8")
+
+    config = GatewayConfig(workspace_path=tmp_path)
+    writer = SlowWriter(config)
+
+    errors = []
+
+    def write(entry):
+        try:
+            writer.write_actionable(entry)
+        except Exception as e:
+            errors.append(f"err: {e}")
+
+    entry_a = _make_entry("race-aaa", tmp_path)
+    entry_b = _make_entry("race-bbb", tmp_path)
+    t1 = threading.Thread(target=write, args=(entry_a,))
+    t2 = threading.Thread(target=write, args=(entry_b,))
+    t1.start()
+    t2.start()
+    t1.join()
+    t2.join()
+
+    assert not errors, f"Thread errors: {errors}"
+    content = writer._heartbeat_path.read_text()
+    assert "race-aaa" in content
+    assert "race-bbb" in content
+
+
+def test_concurrent_writes_via_threads(tmp_path: Path) -> None:
+    """10 threads writing simultaneously — all entries must appear."""
+    import threading
+
+    config = GatewayConfig(workspace_path=tmp_path)
+    writer = HeartbeatWriter(config)
+    errors = []
+
+    def write(i):
+        try:
+            writer.write_actionable(_make_entry(f"run-{i:03d}", tmp_path))
+        except Exception as e:
+            errors.append(e)
+
+    threads = [threading.Thread(target=write, args=(i,)) for i in range(10)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+
+    assert not errors, f"Write errors: {errors}"
+    content = (tmp_path / "HEARTBEAT.md").read_text()
+    for i in range(10):
+        assert f"run-{i:03d}" in content, f"Entry run-{i:03d} missing"

--- a/tests/test_writer.py
+++ b/tests/test_writer.py
@@ -1,3 +1,4 @@
+import json as _json
 from datetime import datetime, timezone
 from pathlib import Path
 
@@ -310,13 +311,9 @@ def test_read_active_tasks_respects_config_limit(tmp_path: Path) -> None:
     assert len(result) <= 100
 
 
-import json as _json
-
-
 def test_write_failed_records_to_audit_log(tmp_path):
     """write_failed must write a JSONL record with status=failed to the audit log."""
     from heartbeat_gateway import NormalizedEvent
-    from datetime import datetime, timezone
 
     config = GatewayConfig(workspace_path=tmp_path)
     writer = HeartbeatWriter(config)

--- a/tests/test_writer.py
+++ b/tests/test_writer.py
@@ -259,3 +259,36 @@ def test_concurrent_writes_via_threads(tmp_path: Path) -> None:
     content = (tmp_path / "HEARTBEAT.md").read_text()
     for i in range(10):
         assert f"run-{i:03d}" in content, f"Entry run-{i:03d} missing"
+
+
+# ---------------------------------------------------------------------------
+# Max active tasks cap enforcement tests
+# ---------------------------------------------------------------------------
+
+
+def test_max_active_tasks_enforced(tmp_path: Path) -> None:
+    """write_actionable must refuse the 4th entry when cap is 3."""
+    config = GatewayConfig(workspace_path=tmp_path, heartbeat_max_active_tasks=3)
+    writer = HeartbeatWriter(config)
+
+    for i in range(3):
+        writer.write_actionable(_make_entry(f"run-fill-{i:03d}", tmp_path))
+
+    overflow_entry = _make_entry("run-overflow", tmp_path)
+    writer.write_actionable(overflow_entry)
+
+    content = (tmp_path / "HEARTBEAT.md").read_text()
+    assert "run-overflow" not in content, "Overflow entry should have been rejected"
+
+
+def test_max_active_tasks_zero_means_unlimited(tmp_path: Path) -> None:
+    """heartbeat_max_active_tasks=0 disables the cap."""
+    config = GatewayConfig(workspace_path=tmp_path, heartbeat_max_active_tasks=0)
+    writer = HeartbeatWriter(config)
+
+    for i in range(25):
+        writer.write_actionable(_make_entry(f"run-unlimited-{i:03d}", tmp_path))
+
+    content = (tmp_path / "HEARTBEAT.md").read_text()
+    for i in range(25):
+        assert f"run-unlimited-{i:03d}" in content

--- a/tests/test_writer.py
+++ b/tests/test_writer.py
@@ -292,3 +292,19 @@ def test_max_active_tasks_zero_means_unlimited(tmp_path: Path) -> None:
     content = (tmp_path / "HEARTBEAT.md").read_text()
     for i in range(25):
         assert f"run-unlimited-{i:03d}" in content
+
+
+def test_read_active_tasks_respects_config_limit(tmp_path: Path) -> None:
+    """read_active_tasks must truncate at active_tasks_chars, not hard-coded 1200."""
+    config = GatewayConfig(workspace_path=tmp_path, active_tasks_chars=100)
+    writer = HeartbeatWriter(config)
+    content = (
+        "## Active Tasks\n"
+        + ACTIVE_TASKS_MARKER
+        + "\n"
+        + "z" * 500
+        + "\n## Completed\n"
+    )
+    (tmp_path / "HEARTBEAT.md").write_text(content)
+    result = writer.read_active_tasks()
+    assert len(result) <= 100

--- a/tests/test_writer.py
+++ b/tests/test_writer.py
@@ -299,13 +299,7 @@ def test_read_active_tasks_respects_config_limit(tmp_path: Path) -> None:
     """read_active_tasks must truncate at active_tasks_chars, not hard-coded 1200."""
     config = GatewayConfig(workspace_path=tmp_path, active_tasks_chars=100)
     writer = HeartbeatWriter(config)
-    content = (
-        "## Active Tasks\n"
-        + ACTIVE_TASKS_MARKER
-        + "\n"
-        + "z" * 500
-        + "\n## Completed\n"
-    )
+    content = "## Active Tasks\n" + ACTIVE_TASKS_MARKER + "\n" + "z" * 500 + "\n## Completed\n"
     (tmp_path / "HEARTBEAT.md").write_text(content)
     result = writer.read_active_tasks()
     assert len(result) <= 100

--- a/uv.lock
+++ b/uv.lock
@@ -629,6 +629,7 @@ version = "0.1.0"
 source = { editable = "." }
 dependencies = [
     { name = "fastapi" },
+    { name = "filelock" },
     { name = "httpx" },
     { name = "litellm" },
     { name = "loguru" },
@@ -651,6 +652,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "fastapi", specifier = ">=0.115.0" },
+    { name = "filelock", specifier = ">=3.13" },
     { name = "httpx", specifier = ">=0.28.0" },
     { name = "litellm", specifier = ">=1.50.0" },
     { name = "loguru", specifier = ">=0.7.0" },

--- a/uv.lock
+++ b/uv.lock
@@ -625,7 +625,7 @@ wheels = [
 
 [[package]]
 name = "heartbeat-gateway"
-version = "0.1.0"
+version = "0.2.0"
 source = { editable = "." }
 dependencies = [
     { name = "fastapi" },


### PR DESCRIPTION
## Summary

This PR addresses all critical issues and deployment gaps identified in the v0.1.1 code review. 11 commits, 15 new tests, all 126 passing.

### Critical Fixes
- **File write race condition** — added `FileLock` (with `.resolve()` path normalization) to `HeartbeatWriter.write_actionable`, preventing concurrent webhook delivery from silently dropping entries
- **`heartbeat_max_active_tasks` hard cap** — was warn-only; now enforces a hard cap with `_count_active_tasks` helper; `0` disables the cap

### Security
- **`GATEWAY_REQUIRE_SIGNATURES`** — new `bool` config flag (default `false`); when `true`, `create_app` raises `ValueError` at startup if any source secret is absent, preventing silent no-auth mode
- **10 KB request body limit** — `_process_webhook` rejects bodies over `MAX_BODY_BYTES = 10 * 1024` with HTTP 413, blocking LLM API abuse via oversized payloads

### Reliability
- **Failed-event audit records** — new `HeartbeatWriter.write_failed()` writes `status=failed` JSONL entries to the audit log when unhandled exceptions occur mid-pipeline; `_process_webhook` tracks `event = None` and calls it in the except block

### Configurability
- **SOUL.md / active tasks excerpt lengths** — `soul_excerpt_chars` and `active_tasks_chars` config fields (default 500 / 1200); wired into `classifier._read_soul_excerpt`, `classifier._read_current_tasks`, and `writer.read_active_tasks`

### Deployment
- **Dockerfile** — non-root `agent` user (UID 1000), `chown` of `/workspace` and `/app`, `VOLUME ["/workspace"]` declaration
- **`railway.toml`** — committed to repo; was documented but missing, requiring manual creation

## Test plan

- [ ] `uv run pytest tests/ -v` — 126 passed, 1 xfailed (intentional race condition demo)
- [ ] `uv run ruff check heartbeat_gateway/ tests/` — clean
- [ ] Verify `GATEWAY_REQUIRE_SIGNATURES=true` fails fast when secrets absent
- [ ] Verify POST with >10 KB body returns 413
- [ ] Verify audit.log contains `status=failed` records when classifier raises

🤖 Generated with [Claude Code](https://claude.com/claude-code)