### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,6 @@
 name: CI
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/kahunahana/heartbeat-gateway/security/code-scanning/1](https://github.com/kahunahana/heartbeat-gateway/security/code-scanning/1)

In general, the fix is to define a `permissions` block in the workflow (either at the top level or per job) that grants only the minimal scopes needed. For this CI job, it appears to only need read access to repository contents to allow `actions/checkout` to work; it does not perform any write operations to the repository or interact with issues, PRs, or other resources.

The best fix without changing functionality is to add a workflow-level `permissions` block directly under the `name: CI` line, setting `contents: read`. This will apply to all jobs that do not override permissions, including the existing `test` job. No other scopes (like `pull-requests`, `issues`, or `packages`) are obviously required by the shown steps, which only perform local commands after checking out code. No additional imports or tooling changes are needed; it is a purely declarative change in `.github/workflows/ci.yml`.

Concretely: in `.github/workflows/ci.yml`, between the existing lines 1 (`name: CI`) and 3 (`on:`), insert a `permissions:` block with `contents: read`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
